### PR TITLE
Fix precision bug on multiplication

### DIFF
--- a/include/HEAAN/arith/Z_Q.h
+++ b/include/HEAAN/arith/Z_Q.h
@@ -290,7 +290,6 @@ bool Z_Q<LOGQ>::is_bigger_than_halfQ()const{
 
 
 // convert to big integer of different size
-// assume the value of Afrom fit in Ato
 template<int LOGQfrom, int LOGQto>
 void resize(const Z_Q<LOGQfrom> &Afrom, Z_Q<LOGQto> &Ato) {
 	bool is_negative = Afrom.is_bigger_than_halfQ();
@@ -306,6 +305,7 @@ void resize(const Z_Q<LOGQfrom> &Afrom, Z_Q<LOGQto> &Ato) {
 		for(int i = 0; i < min(Afrom.get_length(), Ato.get_length()); ++i)
 			Ato.data[i] = Afrom.data[i];
 	}
+	Ato.remove_clutter();
 }
 
 template<int LOGQ>


### PR DESCRIPTION
**Description**
Fixed a bug which has been affecting the precision of multiplication.

The function
```
template<int LOGQfrom, int LOGQto>
void resize(const Z_Q<LOGQfrom> &Afrom, Z_Q<LOGQto> &Ato)
```

was assuming the (absolute) value of Afrom being fit in Ato.

However, the function
```
template<int L, int LOGQ>
void CRT<L, LOGQ>::crt(const uint64_t a_rns[L], Z_Q<LOGQ> &A) const
```
had been executing `resize` out of the assumption,
during the process of multiplying modup-ed polynomial, for ciphertext multiplication.

Such error had been resulting the multiplied polynomials to contain coefficients with additional multiple of whole encryption modulus,
resulting desired value, but with amplified error.
