### PR TITLE
Fix bug for switch key generation

### DIFF
--- a/include/HEAAN/arith/Z_Q.h
+++ b/include/HEAAN/arith/Z_Q.h
@@ -98,9 +98,9 @@ void shift_left ( const Z_Q<LOGQfr>& A,
 	int r=(LOGQto-LOGQfr)%64;
 	for(int i=0;i<(LOGQfr+63)/64;i++)
 		B[i+q]=A[i];
+	for(int i=0;i<q;i++) B[i]=0;
 	if(r == 0)
 		return;
-	for(int i=0;i<q;i++) B[i]=0;
 	uint64_t Bextra=0;
 	for(int i=0;i<(LOGQfr+63)/64;i++){
 		uint64_t temp=B[i+q]>>(64-r);


### PR DESCRIPTION
**Description**
The function
```
template< int LOGQfr, int LOGQto>
void shift_left ( const Z_Q<LOGQfr>& A,
	                    Z_Q<LOGQto>& B )
```

had not been zero-filling the LSBs, when `(LOGQto - LOGQfr) % 64 == 0`.

This had been resulting switch keys to contain error, as big as the plaintext (mod-uped secret key),
so the key switching would not work for the case of on `LOGQ % 64 == 0`.